### PR TITLE
Refactor execution engine

### DIFF
--- a/GeneratorCalculation/Solver.cs
+++ b/GeneratorCalculation/Solver.cs
@@ -156,8 +156,7 @@ namespace GeneratorCalculation
 				}
 
 
-				ReceiveGenerator(pairs, constants);
-				if (i >= pairs.Count)
+				if(ReceiveGenerator(pairs, constants))
 				{
 					i = 0;
 					continue;
@@ -261,7 +260,7 @@ namespace GeneratorCalculation
 		}
 
 
-		static void ReceiveGenerator(List<Generator> pairs, List<string> constants)
+		static bool ReceiveGenerator(List<Generator> pairs, List<string> constants)
 		{
 
 			for (var i = 0; i < pairs.Count; i++)
@@ -328,6 +327,7 @@ namespace GeneratorCalculation
 
 							//Run one more time
 							ReceiveGenerator(pairs, constants);
+							return true;
 						}
 						catch (PaperSyntaxException e)
 						{
@@ -336,6 +336,8 @@ namespace GeneratorCalculation
 					}
 				}
 			}
+
+			return false;
 		}
 
 		static int? Receive(PaperType pendingType, List<Generator> pairs, List<string> constants, int from)

--- a/GeneratorCalculation/Solver.cs
+++ b/GeneratorCalculation/Solver.cs
@@ -309,29 +309,32 @@ namespace GeneratorCalculation
 						else
 							throw new NotImplementedException();
 
-
-						try
+						if (conditions != null)
 						{
-							//pairs[i].Type.Receive.Pop
-							pairs[i].Type = new GeneratorType(pairs[i].Type.ForbiddenBindings, remaining, pairs[i].Type.Yield).ApplyEquation(conditions.ToList());
-							Console.Write($"{pairs[i].Name} becomes {pairs[i].Type}");
-							if (conditions.Count > 0)
+							try
 							{
-								Console.Write(" on the conditions that ");
-								Console.Write(string.Join(", ", conditions.Select(p => $"{p.Key}/{p.Value}")));
+								//pairs[i].Type.Receive.Pop
+								pairs[i].Type = new GeneratorType(pairs[i].Type.ForbiddenBindings, remaining, pairs[i].Type.Yield).ApplyEquation(conditions.ToList());
+								Console.Write($"{pairs[i].Name} becomes {pairs[i].Type}");
+								if (conditions.Count > 0)
+								{
+									Console.Write(" on the conditions that ");
+									Console.Write(string.Join(", ", conditions.Select(p => $"{p.Key}/{p.Value}")));
+								}
+
+								Console.WriteLine(".");
+
+								foreach (int indice in matches.OrderByDescending(v => v))
+									pairs.RemoveAt(indice);
+
+								//Run one more time
+								ReceiveGenerator(pairs, constants);
+								return true;
 							}
-							Console.WriteLine(".");
-
-							foreach (int indice in matches.OrderByDescending(v => v))
-								pairs.RemoveAt(indice);
-
-							//Run one more time
-							ReceiveGenerator(pairs, constants);
-							return true;
-						}
-						catch (PaperSyntaxException e)
-						{
-							Console.WriteLine(e.Message);
+							catch (PaperSyntaxException e)
+							{
+								Console.WriteLine(e.Message);
+							}
 						}
 					}
 				}

--- a/GeneratorCalculation/Solver.cs
+++ b/GeneratorCalculation/Solver.cs
@@ -111,6 +111,33 @@ namespace GeneratorCalculation
 			return Solve(coroutines, constants, steps);
 		}
 
+		static bool RemoveVoid(List<Generator> pairs)
+		{
+			bool isProcessed = false;
+			for (int i = 0; i < pairs.Count; i++)
+			{
+				Generator gx = pairs[i];
+
+				if (gx.Type.Yield == ConcreteType.Void && gx.Type.Receive == ConcreteType.Void)
+				{
+					if (gx.IsInfinite)
+					{
+						Console.WriteLine($"{gx.Name} reached the simplest form. Reset to original.");
+						gx.Type = gx.OriginalType.Clone();
+					}
+					else
+					{
+						Console.WriteLine($"{gx.Name} reached the simplest form. Remove from the list.");
+						pairs.RemoveAt(i);
+						i--;
+					}
+					isProcessed = true;
+				}
+			}
+
+			return isProcessed;
+		}
+
 
 		static GeneratorType Solve(List<Generator> pairs, List<string> constants, int steps)
 		{
@@ -135,32 +162,19 @@ namespace GeneratorCalculation
 				}
 
 
-				var coroutine = pairs[i].Type;
-
-				if (coroutine.Yield == ConcreteType.Void && coroutine.Receive == ConcreteType.Void)
+				if (RemoveVoid(pairs))
 				{
-					Generator gx = pairs[i];
-					if (gx.IsInfinite)
-					{
-						Console.WriteLine($"{gx.Name} reached the simplest form. Reset to original.");
-						gx.Type = gx.OriginalType.Clone();
-						i = 0;
-					}
-					else
-					{
-						Console.WriteLine($"{gx.Name} reached the simplest form. Remove from the list.");
-						pairs.RemoveAt(i);
-					}
-
+					i = 0;
 					continue;
 				}
-
 
 				if(ReceiveGenerator(pairs, constants))
 				{
 					i = 0;
 					continue;
 				}
+
+				var coroutine = pairs[i].Type;
 
 
 				PaperType yieldedType = null;


### PR DESCRIPTION
Extract RemoveVoid() and ReceiveGenerator(), and treat them in the same way.

As long as the two methods have processed any coroutines, execution restarts at index 0.